### PR TITLE
Fixed a bug on the column width with content white-space nowrap

### DIFF
--- a/sass/_flexbox-grid-mixins.scss
+++ b/sass/_flexbox-grid-mixins.scss
@@ -109,6 +109,7 @@
 	}
 
 	flex: $flex-grow $flex-shrink $flex-basis;
+	max-width: $flex-basis;
 
 	@if $align-self {
 		align-self: $align-self;


### PR DESCRIPTION
Whenever a grid column containss a paragraph with a `white-space: nowrap;` CSS rule,
the grid column width will go over what's expected.